### PR TITLE
Add public statement announcing Governable-AGI Charter v1.1 adoption

### DIFF
--- a/docs/public_statement_governable_agi_charter_v1_1.md
+++ b/docs/public_statement_governable_agi_charter_v1_1.md
@@ -1,0 +1,9 @@
+# Public Statement: Adoption of the Governable-AGI Charter v1.1
+
+**Date:** 2024-06-04
+
+Today we are adopting the Governable-AGI Charter v1.1, a self-limiting framework that puts safety and accountability ahead of capability. Effective immediately, we commit to least-capability operation, independent oversight with pause authority, capability-linked release gates, and hard bans on covert channels, targeted persuasion, and bio/cyber planning.
+
+All high-impact outputs carry provenance; activity is recorded with tamper-evident logs and attested builds. Automatic tripwires trigger safe-mode and review. We will publish safety dossiers for new tools, accept continuous red-team testing, and disclose incidents within 72 hours with reproducible artifacts.
+
+A machine-readable model-card addendum outlines constraints and tripwires. This charter is open for scrutiny and improvement—our goal is trustworthy usefulness, verified by controls we do not hold. Help test it, question it, iterate, together.


### PR DESCRIPTION
## Summary
- add a public statement documenting the adoption of the Governable-AGI Charter v1.1 and its associated safety commitments

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e5ad1bdf5c832cafd847ac9d09c25b